### PR TITLE
Use sysconfig for Python dll locations

### DIFF
--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -513,9 +513,11 @@ log_status "Stripping Python cache files (*.pyc,*.pyo,__pycache__)..."
 find "$RELEASE/lib/$PYVER" -regextype sed -regex ".*\.py[co]" | xargs rm -rfv
 find "$RELEASE/lib/$PYVER" -name "__pycache__" | xargs rm -rfv
 
+PY_DLLS_SRC_PATH=`/$MINGVER/bin/python.exe -c "import sysconfig as sc; print(sc.get_path('platlib', sc.get_preferred_scheme('user'), vars={'userbase': '.'}))"`
+
 log_status "Copying the Python extension dlls..."
-cp -f "$TARGET/lib/$PYVER/site-packages/fontforge.pyd" "$RELEASE/lib/$PYVER/site-packages/" || bail "Couldn't copy pyhook dlls"
-cp -f "$TARGET/lib/$PYVER/site-packages/psMat.pyd" "$RELEASE/lib/$PYVER/site-packages/" || bail "Couldn't copy pyhook dlls"
+cp -f "$TARGET/$PY_DLLS_SRC_PATH/fontforge.pyd" "$RELEASE/lib/$PYVER/site-packages/" || bail "Couldn't copy pyhook dlls"
+cp -f "$TARGET/$PY_DLLS_SRC_PATH/psMat.pyd" "$RELEASE/lib/$PYVER/site-packages/" || bail "Couldn't copy pyhook dlls"
 
 ffex=`which fontforge.exe`
 MSYSROOT=`cygpath -w /`


### PR DESCRIPTION
[distutils](https://docs.python.org/3.10/library/distutils.html#module-distutils) is deprecated with removal planned for Python 3.12.

Replace distutils with a similar functionality from sysconfig to avoid CI failure.

This change is necessary to update CI to macos-12, which doesn't have Python 3.10.

Please review this PR together with the related https://github.com/fontforge/fontforge/pull/5423