### PR TITLE
Split some pacman commands to single packages

### DIFF
--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -266,11 +266,14 @@ if (( ! $nomake )) && [ ! -f $PMTEST ]; then
     pacman $IOPTS $PMPREFIX-{gcc,gmp,ntldd-git,gettext,libiconv,cmake,ninja,ccache}
 
     ## Other libs
-    pacman $IOPTS $PMPREFIX-{$PYINST,$PYINST-pip,$PYINST-setuptools}
+    pacman $IOPTS $PMPREFIX-$PYINST
+    pacman $IOPTS $PMPREFIX-$PYINST-pip
+    pacman $IOPTS $PMPREFIX-$PYINST-setuptools
 
     log_status "Installing precompiled devel libraries..."
     # Libraries
-    pacman $IOPTS $PMPREFIX-{libspiro,libuninameslist}
+    pacman $IOPTS $PMPREFIX-libspiro
+    pacman $IOPTS $PMPREFIX-libuninameslist
     pacman $IOPTS $PMPREFIX-{zlib,libpng,giflib,libtiff,libjpeg-turbo,libxml2,potrace}
     pacman $IOPTS $PMPREFIX-{freetype,fontconfig,glib2,pixman,harfbuzz,woff2}
     


### PR DESCRIPTION
It's not clear to me why `pacman` is sometimes failing to install multiple packages at once. Splitting the command helps. 

There was no update to the pacman itself, and I couldn't reproduce this on my home laptop, so maybe it's some obscure GitHub runner environment issue.

CI failure: https://github.com/fontforge/fontforge/actions/runs/12185748774/job/33992682817?pr=5506 - see multiple `error: target not found` errors.

Successful test for this PR: https://github.com/iorsh/fontforge/commit/6c88972c463b563aab78b81ef1636c35e70512a2