### PR TITLE
Pacman python installation

### DIFF
--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -248,7 +248,7 @@ if (( ! $nomake )) && [ ! -f $PMTEST ]; then
     #    pacman-key --lsign-key 90F90C4A || bail "Could not add fontforgelibs signing key"
     #fi
 
-    pacman -Sy --noconfirm
+    pacman -Syy --noconfirm
 
     IOPTS="-S --noconfirm --needed"
 

--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -194,7 +194,7 @@ detect_arch_switch $MINGVER
 TARGET=$BASE/target/$MINGVER/
 WORK=$BASE/work/$MINGVER/
 PMTEST="$BASE/.pacman-$MINGVER-installed"
-PYINST=python3
+PYINST=python
 
 # Check for AppVeyor specific settings
 if (($appveyor)); then


### PR DESCRIPTION
This is a hack intended to overcome issues with Python3 installation via `pacman`. There is probably some instability in GitHub MSYS2 environment, as I can't see a reasonable explanation for these changes.

- `python3` is an alias for `python`, and package e.g. `mingw-w64-i686-python3-pip` should point to `mingw-w64-i686-python-pip`. For some reason it doesn't.
- We are forcing pacman database refresh with `-yy`, but it shouldn't be necessary in a freshly installed MSYS2 environment.

