### PR TITLE
Use modern Windows building environments

### DIFF
--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -173,6 +173,7 @@ elif [ "$MSYSTEM" = "CLANGARM64" ]; then
 else
     bail "Unknown build system!"
 fi
+export PMPREFIX
 
 # Early detection
 detect_arch_switch $MINGVER

--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -162,18 +162,16 @@ if [ "$MSYSTEM" = "UCRT64" ]; then
     ARCHNUM="64"
     MINGVER=ucrt64
     PMARCH=ucrt-x86_64
-    PMPREFIX="mingw-w64-$PMARCH"
 elif [ "$MSYSTEM" = "CLANGARM64" ]; then
     log_note "Building ARM 64-bit version!"
 
     ARCHNUM="64"
     MINGVER=clangarm64
     PMARCH=clang-aarch64
-    PMPREFIX="mingw-w64-$PMARCH"
 else
     bail "Unknown build system!"
 fi
-export PMPREFIX
+export PMPREFIX="mingw-w64-$PMARCH"
 
 # Early detection
 detect_arch_switch $MINGVER

--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -446,7 +446,7 @@ fi
 
 
 log_status "Installing run_fontforge..."
-objcopy -S --file-alignment 1024 $WORK/run_fontforge/run_fontforge.exe "$RELEASE/run_fontforge.exe" \
+strip $WORK/run_fontforge/run_fontforge.exe -so "$RELEASE/run_fontforge.exe" \
     || bail "run_fontforge"
 
 log_status "Copying UI fonts..."

--- a/ffbuild.sh
+++ b/ffbuild.sh
@@ -155,33 +155,20 @@ BINARY=$BASE/original-archives/binaries/
 RELEASE=$BASE/ReleasePackage/
 DBSYMBOLS=$BASE/debugging-symbols/.debug/
 
-# Determine if we're building 32 or 64 bit.
-if [ "$MSYSTEM" = "MINGW32" ]; then
-    log_note "Building 32-bit version!"
+# Determine if we're building x86 or arm64 bit.
+if [ "$MSYSTEM" = "UCRT64" ]; then
+    log_note "Building x86 64-bit ucrt version!"
 
-    ARCHNUM="32"
-    MINGVER=mingw32
-    MINGOTHER=mingw64
-    HOST="--build=i686-w64-mingw32 --host=i686-w64-mingw32 --target=i686-w64-mingw32"
-    PMARCH=i686
-    PMPREFIX="mingw-w64-$PMARCH"
-elif [ "$MSYSTEM" = "MINGW64" ]; then
-    log_note "Building 64-bit version!"
-
-    ARCHNUM="64"
-    MINGVER=mingw64
-    MINGOTHER=mingw32
-    HOST="--build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32"
-    PMARCH=x86_64
-    PMPREFIX="mingw-w64-$PMARCH"
-elif [ "$MSYSTEM" = "UCRT64" ]; then
-    log_note "Building 64-bit ucrt version!"
-    
     ARCHNUM="64"
     MINGVER=ucrt64
-    MINGOTHER=mingw32
-    HOST="--build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32"
     PMARCH=ucrt-x86_64
+    PMPREFIX="mingw-w64-$PMARCH"
+elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+    log_note "Building ARM 64-bit version!"
+
+    ARCHNUM="64"
+    MINGVER=clangarm64
+    PMARCH=clang-aarch64
     PMPREFIX="mingw-w64-$PMARCH"
 else
     bail "Unknown build system!"
@@ -340,18 +327,9 @@ if (( ! $nomake )); then
     log_status "Finished installing prerequisites, attempting to install FontForge!"
     # fontforge
     if (( ! ($appveyor+$ghactions) )) && [ ! -d fontforge ]; then
-            if [ -d "$BASE/work/$MINGOTHER/fontforge" ]; then
-                log_status "Found copy from other arch build, performing local clone..."
-                # Don't use git clone - need the remotes for updating
-                cp -r "$BASE/work/$MINGOTHER/fontforge" . || bail "Local clone failed"
-                cd "fontforge"
-                git clean -dxf || bail "Could not clean repository"
-                git reset --hard || bail "Could not reset repository"
-            else
-                log_status "Cloning the fontforge repository from https://github.com/$github/fontforge..."
-                git clone "https://github.com/$github/fontforge" || bail "Cloning fontforge"
-                cd "fontforge"
-            fi
+        log_status "Cloning the fontforge repository from https://github.com/$github/fontforge..."
+        git clone "https://github.com/$github/fontforge" || bail "Cloning fontforge"
+        cd "fontforge"
     else
         cd "$FFPATH";
     fi

--- a/fontforge-setup/fontforgesetup.iss
+++ b/fontforge-setup/fontforgesetup.iss
@@ -11,19 +11,21 @@
 #define MyInstallEpoch "1"
 
 #ifdef MSYSTEM
-# if MSYSTEM == "MINGW64"
-#  define ARCH="x64"
+# if MSYSTEM == "UCRT64"
+#  define ARCH="x64compatible"
 #  define ARCHDESC="x64"
-#  define ARCHBITS="64"
-#  define OTHERBITS="32"
+# endif
+# if MSYSTEM == "CLANGARM64"
+#  define ARCH="arm64"
+#  define ARCHDESC="arm64"
 # endif
 #endif
 #ifndef ARCH
-# define ARCH=""
-# define ARCHDESC="x86"
-# define ARCHBITS="32"
-# define OTHERBITS="64"
+# define ARCH="x64"
+# define ARCHDESC="x64_unknown"
 #endif
+#define ARCHBITS="64"
+#define OTHERBITS="32"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.

--- a/make-portable-package.sh
+++ b/make-portable-package.sh
@@ -49,22 +49,24 @@ else
     postfix="$1"
 fi
 
-if [ "$MSYSTEM" = "MINGW32" ]; then
-    ARCH="32"
-    PKGPREFIX="FontForge-mingw-w64-i686"
+if [ "$MSYSTEM" = "UCRT64" ]; then
+    MINGVER=ucrt64
+    PMARCH=ucrt-x86_64
+elif [ "$MSYSTEM" = "CLANGARM64" ]; then
+    MINGVER=clangarm64
+    PMARCH=clang-aarch64
 else
-    ARCH="64"
-    PKGPREFIX="FontForge-mingw-w64-x86_64"
+    bail "Unknown build system!"
 fi
+PKGPREFIX="FontForge-mingw-w64-$PMARCH"
 
-MINGVER=mingw$ARCH
 BASE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SETUP=$BASE/fontforge-setup
 WORK=$BASE/work/$MINGVER/
 RELEASE=$BASE/ReleasePackage/
 DEBUG=$BASE/debugging-symbols/
 
-log_note "Packaging $ARCH-bit release..."
+log_note "Packaging $MINGVER release..."
 pacman -S --noconfirm --needed p7zip > /dev/null 2>&1 
 
 if [ -z "$FFPATH" ]; then

--- a/strip-python.sh
+++ b/strip-python.sh
@@ -6,15 +6,9 @@ set -eo pipefail
 
 export LC_ALL=C
 
-if [ "$MSYSTEM" == "MINGW32" ]; then
-    PACKAGE=mingw-w64-i686-python
-    PIP_PACKAGE=mingw-w64-i686-python-pip
-    SETUPTOOLS_PACKAGE=mingw-w64-i686-python-setuptools
-else
-    PACKAGE=mingw-w64-x86_64-python
-    PIP_PACKAGE=mingw-w64-x86_64-python-pip
-    SETUPTOOLS_PACKAGE=mingw-w64-x86_64-python-setuptools
-fi
+PACKAGE=$PMPREFIX-python
+PIP_PACKAGE=$PMPREFIX-python-pip
+SETUPTOOLS_PACKAGE=$PMPREFIX-python-setuptools
 
 #PYNAME=$(pacman -Qi $PACKAGE | grep -m1 Name | cut -d':' -f2 | xargs) # only needed for the python3 transition to default
 PYNAME="$PACKAGE"


### PR DESCRIPTION
`MINGW32` and `MINGW64` environments are deprecated - see https://www.msys2.org/news/#2026-03-15-soft-deprecating-the-mingw64-environment, https://www.msys2.org/news/#2023-12-13-starting-to-drop-some-32-bit-packages . Specifically, `MINGW32` is now broken beyond repair after `libc++` was dropped in https://github.com/msys2/MINGW-packages/commit/5b145149cdc1c08eeae446a56d1b9281c1f9e2b1

This PR introduces the recommended building environments `UCRT64` for x86_64 and `CLANGARM64` for aarch64.

Ref: https://www.msys2.org/docs/environments/#__tabbed_1_1